### PR TITLE
Fixes redis 3.0 breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'click',
         'flask-admin',
-        'redis',
+        'redis<3.0',
         'structlog',
         'tasktiger>=0.4',
     ],


### PR DESCRIPTION
Redis 3.0 has some breaking changes. This project was built on redis 2.x, so not allowing <3.0 is necessary so the project won't break.